### PR TITLE
add basic wodin deploy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           hatch run lint:style
       - name: Test
         run: |
-          hatch run cov-ci
+          hatch run cov
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
+          directory: ./..

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,8 @@ jobs:
           hatch run lint:style
       - name: Test
         run: |
-          hatch run cov
+          hatch run cov-ci
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
-          directory: ./..

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+env:
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+      - name: Lint
+        run: |
+          hatch run lint:style
+      - name: Test
+        run: |
+          hatch run cov-ci
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 .idea
 .pytest_cache
 __pycache__
-siteConfigs
-proxyIndexPage
 .coverage
 .ruff_cache
 .coverage.*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ siteConfigs
 proxyIndexPage
 .coverage
 .ruff_cache
+.coverage.*

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 siteConfigs
 proxyIndexPage
 .coverage
+.ruff_cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+.pytest_cache
+__pycache__
+siteConfigs
+proxyIndexPage

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 siteConfigs
 proxyIndexPage
+.coverage

--- a/README.md
+++ b/README.md
@@ -5,6 +5,36 @@
 
 -----
 
+## Installing packages
+Hatch will automatically install and sync dependencies whenever you run any
+```commandline
+hatch run ...
+```
+command
+
+## Testing
+### To run all
+```commandline
+hatch run test
+```
+
+### To run within directory
+```commandline
+hatch run test ./directory/
+```
+
+### To run within file
+```commandline
+hatch run test ./path/to/file/test_file.py
+```
+
+### To run specific tests
+```commandline
+hatch run tests ./test_file_1.py::test_name_1 ./test_file_2.py::test_name_2
+```
+
+-----
+
 ## Moving parts
 
 **NOTE: this documentation describes the state that the deployment tool will reach once fully implemented, not what currently is implemented**

--- a/config/epimodels.yml
+++ b/config/epimodels.yml
@@ -1,0 +1,71 @@
+# Prefix for container names; we'll use {container_prefix}-(container_name)
+container_prefix: epimodels
+
+# Docker org for images
+repo: mrcide
+
+network: wodin-nw
+
+## Domain where the sites will be deployed. E.g. epimodels.dide.ic.ac.uk
+#hostname: localhost
+
+# Configuration for wodin sites
+# url: url of the github repo containing the configuration
+# ref: branch of the repo defined in the url you want to pull
+# urlPath: if set to "demoUrlPath" for example app will be on epimodels.dide.ic.ac.uk/demoUrlPath
+# description: the description that shows up on the index page at epimodels.dide.ic.ac.uk
+
+sites:
+  demo:
+    url: https://github.com/mrc-ide/wodin-demo-config
+    ref: main
+    urlPath: demo
+    description: A demo of core app types and configuration
+  msc-idm-2022:
+    url: https://github.com/mrc-ide/wodin-msc-idm-2022
+    ref: main
+    urlPath: msc-2022
+    description: The 2022 MSc course
+  msc-idm-2023:
+    url: https://github.com/mrc-ide/wodin-msc-idm-2023
+    ref: main
+    urlPath: msc-2023
+    description: The 2023 MSc course
+  malawi-idm-2022:
+    url: https://github.com/mrc-ide/wodin-malawi-idm-2022
+    ref: main
+    urlPath: malawi-2022
+    description: Infectious Disease Modelling with a focus on Malaria, run in Malawi
+  gambia-idm-2023:
+    url: https://github.com/mrc-ide/wodin-gambia-idm-2023
+    ref: main
+    urlPath: gambia-2023
+    description: Infectious Disease Modelling with a focus on Malaria, run in The Gambia
+  acomvec-2023:
+    url: https://github.com/mrc-ide/wodin-acomvec-2023
+    ref: main
+    urlPath: cameroon-2023
+    description: Infectious Disease Modelling with a focus on Malaria, run in Cameroon
+  infectiousdiseasemodels-2023:
+    url: https://github.com/mrc-ide/wodin-shortcourse-2023
+    ref: main
+    urlPath: shortcourse
+    description: Introduction to Mathematical Models of the Epidemiology & Control of Infectious Diseases (the DIDE short course), 2023
+
+odin.api:
+  ref: main
+
+wodin-proxy:
+  ref: latest
+  port_http: 80
+  port_https: 443
+  ssl:
+    certificate: VAULT:secret/wodin/ssl/epimodels:cert
+    key: VAULT:secret/wodin/ssl/epimodels:key
+
+wodin:
+  ref: main
+
+redis:
+  repo: library
+  ref: "6"

--- a/config/epimodels.yml
+++ b/config/epimodels.yml
@@ -64,7 +64,7 @@ wodin-proxy:
     key: VAULT:secret/wodin/ssl/epimodels:key
 
 wodin:
-  ref: wodin-deploy-script-test
+  ref: main
 
 redis:
   repo: library

--- a/config/epimodels.yml
+++ b/config/epimodels.yml
@@ -68,4 +68,4 @@ wodin:
 
 redis:
   repo: library
-  ref: "6"
+  ref: "6.0"

--- a/config/epimodels.yml
+++ b/config/epimodels.yml
@@ -64,7 +64,7 @@ wodin-proxy:
     key: VAULT:secret/wodin/ssl/epimodels:key
 
 wodin:
-  ref: main
+  ref: wodin-deploy-script-test
 
 redis:
   repo: library

--- a/config/epimodels.yml
+++ b/config/epimodels.yml
@@ -6,9 +6,6 @@ repo: mrcide
 
 network: wodin-nw
 
-## Domain where the sites will be deployed. E.g. epimodels.dide.ic.ac.uk
-#hostname: localhost
-
 # Configuration for wodin sites
 # url: url of the github repo containing the configuration
 # ref: branch of the repo defined in the url you want to pull

--- a/config/epimodels.yml
+++ b/config/epimodels.yml
@@ -53,7 +53,7 @@ odin.api:
   ref: main
 
 wodin-proxy:
-  ref: latest
+  ref: main
   port_http: 80
   port_https: 443
   ssl:

--- a/config/epimodels.yml
+++ b/config/epimodels.yml
@@ -51,6 +51,7 @@ sites:
 
 odin.api:
   ref: main
+  container_name: api
 
 wodin-proxy:
   ref: main

--- a/config/test.yml
+++ b/config/test.yml
@@ -39,6 +39,7 @@ wodin-proxy:
     key: VAULT:secret/wodin/ssl/epimodels:key
 
 wodin:
+  name: wodin
   ref: main
 
 redis:

--- a/config/test.yml
+++ b/config/test.yml
@@ -1,19 +1,8 @@
-# Prefix for container names; we'll use {container_prefix}-(container_name)
 container_prefix: test-prefix
 
-# Docker org for images
 repo: test-repo
 
 network: test-network
-
-## Domain where the sites will be deployed. E.g. epimodels.dide.ic.ac.uk
-#hostname: localhost
-
-# Configuration for wodin sites
-# url: url of the github repo containing the configuration
-# ref: branch of the repo defined in the url you want to pull
-# urlPath: if set to "demoUrlPath" for example app will be on epimodels.dide.ic.ac.uk/demoUrlPath
-# description: the description that shows up on the index page at epimodels.dide.ic.ac.uk
 
 sites:
   demo:

--- a/config/test.yml
+++ b/config/test.yml
@@ -20,7 +20,7 @@ odin.api:
   ref: main
 
 wodin-proxy:
-  ref: latest
+  ref: main
   port_http: 80
   port_https: 443
   ssl:

--- a/config/test.yml
+++ b/config/test.yml
@@ -1,0 +1,46 @@
+# Prefix for container names; we'll use {container_prefix}-(container_name)
+container_prefix: test-prefix
+
+# Docker org for images
+repo: test-repo
+
+network: test-network
+
+## Domain where the sites will be deployed. E.g. epimodels.dide.ic.ac.uk
+#hostname: localhost
+
+# Configuration for wodin sites
+# url: url of the github repo containing the configuration
+# ref: branch of the repo defined in the url you want to pull
+# urlPath: if set to "demoUrlPath" for example app will be on epimodels.dide.ic.ac.uk/demoUrlPath
+# description: the description that shows up on the index page at epimodels.dide.ic.ac.uk
+
+sites:
+  demo:
+    url: https://github.com/mrc-ide/wodin-demo-config
+    ref: main
+    urlPath: demo
+    description: test desc for demo
+  shortcourse:
+    url: https://github.com/mrc-ide/wodin-shortcourse-2023
+    ref: main
+    urlPath: shortcourse
+    description: test desc for shortcourse
+
+odin.api:
+  ref: main
+
+wodin-proxy:
+  ref: latest
+  port_http: 80
+  port_https: 443
+  ssl:
+    certificate: VAULT:secret/wodin/ssl/epimodels:cert
+    key: VAULT:secret/wodin/ssl/epimodels:key
+
+wodin:
+  ref: main
+
+redis:
+  repo: library
+  ref: "6"

--- a/config/test.yml
+++ b/config/test.yml
@@ -17,7 +17,9 @@ sites:
     description: test desc for shortcourse
 
 odin.api:
+  container_name: api
   ref: main
+  image_name: odin-image
 
 wodin-proxy:
   ref: main

--- a/config/test.yml
+++ b/config/test.yml
@@ -43,4 +43,4 @@ wodin:
 
 redis:
   repo: library
-  ref: "6"
+  ref: "6.0"

--- a/config/testNoSSL.yml
+++ b/config/testNoSSL.yml
@@ -1,19 +1,8 @@
-# Prefix for container names; we'll use {container_prefix}-(container_name)
 container_prefix: test-prefix
 
-# Docker org for images
 repo: test-repo
 
 network: test-network
-
-## Domain where the sites will be deployed. E.g. epimodels.dide.ic.ac.uk
-#hostname: localhost
-
-# Configuration for wodin sites
-# url: url of the github repo containing the configuration
-# ref: branch of the repo defined in the url you want to pull
-# urlPath: if set to "demoUrlPath" for example app will be on epimodels.dide.ic.ac.uk/demoUrlPath
-# description: the description that shows up on the index page at epimodels.dide.ic.ac.uk
 
 sites:
   demo:

--- a/config/testNoSSL.yml
+++ b/config/testNoSSL.yml
@@ -20,7 +20,7 @@ odin.api:
   ref: main
 
 wodin-proxy:
-  ref: latest
+  ref: main
   port_http: 80
   port_https: 443
 

--- a/config/testNoSSL.yml
+++ b/config/testNoSSL.yml
@@ -34,9 +34,6 @@ wodin-proxy:
   ref: latest
   port_http: 80
   port_https: 443
-  ssl:
-    certificate: test-cert
-    key: test-key
 
 wodin:
   name: wodin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ path = "wodin_deploy/__about__.py"
 dependencies = [
   "pytest",
   "pytest-cov",
+  "coverage[toml]>=6.5",
 ]
 [tool.hatch.envs.default.scripts]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=wodin_deploy --cov=tests {args}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "coverage[toml]>=6.5",
-  "constellation@git+https://github.com/reside-ic/constellation@add-preconfigure",
+  "constellation>=1.2.4",
   "docker"
 ]
 [tool.hatch.envs.default.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,9 @@ dependencies = [
 ]
 
 dynamic = ["version"]
-[project.dynamic]
-version = {attr = "wodin_deploy.__version__"}
+
+[tool.hatch.version]
+path = "wodin_deploy/__about__.py"
 
 [project.urls]
 Documentation = "https://github.com/mrc-ide/wodin-deploy#readme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,103 @@ omit = [
   "wodin_deploy/__about__.py",
 ]
 
+[tool.hatch.envs.lint]
+detached = true
+dependencies = [
+  "black>=23.1.0",
+  "mypy>=1.0.0",
+  "ruff>=0.0.243",
+]
+[tool.hatch.envs.lint.scripts]
+typing = "mypy --install-types --non-interactive {args:wodin_deploy tests}"
+style = [
+  "ruff {args:.}",
+  "black --check --diff {args:.}",
+]
+fmt = [
+  "black {args:.}",
+  "ruff --fix {args:.}",
+  "style",
+]
+all = [
+  "style",
+  "typing",
+]
+
+[tool.black]
+target-version = ["py37"]
+line-length = 120
+skip-string-normalization = true
+
+[tool.ruff]
+target-version = "py37"
+line-length = 120
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "DTZ",
+  "E",
+  "EM",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "ISC",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
+ignore = [
+  # Allow non-abstract empty methods in abstract base classes
+  "B027",
+  # Allow boolean positional values in function calls, like `dict.get(... True)`
+  "FBT003",
+  # Ignore checks for possible passwords
+  "S105", "S106", "S107",
+  # Ignore complexity
+  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+  # Ignore print statements
+  "T201"
+]
+unfixable = [
+  # Don't touch unused imports
+  "F401",
+]
+
+[tool.ruff.isort]
+known-first-party = ["wodin_deploy"]
+
+[tool.ruff.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.per-file-ignores]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
+
+[tool.coverage.run]
+source = ["src"]
+branch = true
+parallel = true
+omit = [
+  "wodin_deploy/__about__.py",
+]
+
+[tool.coverage.paths]
+wodin_deploy = ["wodin_deploy"]
+tests = ["tests"]
+
 [tool.coverage.report]
 exclude_lines = [
   "no cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,14 +143,6 @@ ban-relative-imports = "all"
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 
-[tool.coverage.run]
-source = ["src"]
-branch = true
-parallel = true
-omit = [
-  "wodin_deploy/__about__.py",
-]
-
 [tool.coverage.paths]
 wodin_deploy = ["wodin_deploy"]
 tests = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
 dependencies = [
 #  "constellation>=1.2.3",
   "constellation@git+https://github.com/reside-ic/constellation#egg=add-preconfigure"
@@ -43,6 +47,8 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "coverage[toml]>=6.5",
+  "constellation@git+https://github.com/reside-ic/constellation@add-preconfigure",
+  "docker"
 ]
 [tool.hatch.envs.default.scripts]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=wodin_deploy --cov=tests {args}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ ban-relative-imports = "all"
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 
 [tool.coverage.run]
-src = ["."]
 branch = true
 parallel = true
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wodin-deploy"
+dynamic = ["version"]
 description = 'Deploy tool for wodin instances'
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = "MIT"
 keywords = []
 authors = [
@@ -24,15 +25,14 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
 dependencies = [
 #  "constellation>=1.2.3",
-  "constellation@git+https://github.com/reside-ic/constellation#egg=add-preconfigure"
+  "constellation@git+https://github.com/reside-ic/constellation#egg=add-preconfigure",
+  "docker"
 ]
 
-dynamic = ["version"]
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [project.urls]
 Documentation = "https://github.com/mrc-ide/wodin-deploy#readme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
 ]
 
 dynamic = ["version"]
+[tool.setuptools.dynamic]
+version = {attr = "wodin_deploy.__version__"}
 
 [project.urls]
 Documentation = "https://github.com/mrc-ide/wodin-deploy#readme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 ]
 
 dynamic = ["version"]
-[tool.setuptools.dynamic]
+[project.dynamic]
 version = {attr = "wodin_deploy.__version__"}
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wodin-deploy"
-description = ''
+description = 'Deploy tool for wodin instances'
 readme = "README.md"
 requires-python = ">=3.7"
 license = "MIT"
@@ -23,7 +23,11 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = []
+dependencies = [
+#  "constellation>=1.2.3",
+  "constellation@git+https://github.com/reside-ic/constellation#egg=add-preconfigure"
+]
+
 dynamic = ["version"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,6 @@ dependencies = [
 
 dynamic = ["version"]
 
-[tool.hatch.version]
-path = "wodin_deploy/__about__.py"
-
 [project.urls]
 Documentation = "https://github.com/mrc-ide/wodin-deploy#readme"
 Issues = "https://github.com/mrc-ide/wodin-deploy/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,9 @@ classifiers = [
 ]
 
 dependencies = [
-#  "constellation>=1.2.4",
-  "constellation@git+https://github.com/reside-ic/constellation@master",
+  "constellation>=1.2.4",
   "docker"
 ]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [project.urls]
 Documentation = "https://github.com/mrc-ide/wodin-deploy#readme"
@@ -47,8 +43,7 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "coverage[toml]>=6.5",
-#  "constellation>=1.2.4",
-  "constellation@git+https://github.com/reside-ic/constellation@master",
+  "constellation>=1.2.4",
   "docker"
 ]
 [tool.hatch.envs.default.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,13 +57,6 @@ no-cov = "cov --no-cov {args}"
 [[tool.hatch.envs.test.matrix]]
 python = ["37", "38", "39", "310", "311"]
 
-[tool.coverage.run]
-branch = true
-parallel = true
-omit = [
-  "wodin_deploy/__about__.py",
-]
-
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [
@@ -148,6 +141,14 @@ ban-relative-imports = "all"
 [tool.ruff.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
+
+[tool.coverage.run]
+src = ["."]
+branch = true
+parallel = true
+omit = [
+  "wodin_deploy/__about__.py",
+]
 
 [tool.coverage.paths]
 wodin_deploy = ["wodin_deploy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 dependencies = [
 #  "constellation>=1.2.3",
-  "constellation@git+https://github.com/reside-ic/constellation#egg=add-preconfigure",
+  "constellation@git+https://github.com/reside-ic/constellation@add-preconfigure",
   "docker"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,6 @@ omit = [
 
 [tool.coverage.paths]
 wodin_deploy = ["wodin_deploy"]
-tests = ["tests"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
 ]
 
 dependencies = [
-#  "constellation>=1.2.3",
-  "constellation@git+https://github.com/reside-ic/constellation@add-preconfigure",
+#  "constellation>=1.2.4",
+  "constellation@git+https://github.com/reside-ic/constellation@master",
   "docker"
 ]
 
@@ -47,7 +47,8 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "coverage[toml]>=6.5",
-  "constellation>=1.2.4",
+#  "constellation>=1.2.4",
+  "constellation@git+https://github.com/reside-ic/constellation@master",
   "docker"
 ]
 [tool.hatch.envs.default.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,24 @@ dependencies = [
   "docker"
 ]
 [tool.hatch.envs.default.scripts]
-cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=wodin_deploy --cov=tests {args}"
-no-cov = "cov --no-cov {args}"
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+cov-report = [
+  "- coverage combine",
+  "coverage report",
+]
+cov-report-xml = [
+    "- coverage combine",
+    "coverage xml",
+]
+cov = [
+  "test-cov",
+  "cov-report",
+]
+cov-ci = [
+    "test-cov",
+    "cov-report-xml",
+]
 
 [[tool.hatch.envs.test.matrix]]
 python = ["37", "38", "39", "310", "311"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,32 @@
+from wodin_deploy.config import WodinConfig
+
+
+def test_config_basic():
+    cfg = WodinConfig("config/test")
+    assert cfg.network == "test-network"
+    assert cfg.repo == "test-repo"
+    assert cfg.container_prefix == "test-prefix"
+    assert cfg.sites == {
+        "demo": {
+            "url": "https://github.com/mrc-ide/wodin-demo-config",
+            "ref": "main",
+            "urlPath": "demo",
+            "description": "test desc for demo"
+        },
+        "shortcourse": {
+            "url": "https://github.com/mrc-ide/wodin-shortcourse-2023",
+            "ref": "main",
+            "urlPath": "shortcourse",
+            "description": "test desc for shortcourse"
+        },
+    }
+    assert cfg.redis["name"] == "redis"
+    assert str(cfg.redis["ref"]) == "library/redis:6"
+    assert cfg.odin_api["name"] == "odin.api"
+    assert str(cfg.odin_api["ref"]) == "test-repo/odin.api:main"
+    assert cfg.wodin["name"] == "wodin"
+    assert str(cfg.wodin["ref"]) == "test-repo/wodin:main"
+    assert cfg.wodin_proxy["name"] == "wodin-proxy"
+    assert str(cfg.wodin_proxy["ref"]) == "test-repo/wodin-proxy:latest"
+    assert cfg.wodin_proxy["port_http"] == 80
+    assert cfg.wodin_proxy["port_https"] == 443

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,13 +11,13 @@ def test_config_basic():
             "url": "https://github.com/mrc-ide/wodin-demo-config",
             "ref": "main",
             "urlPath": "demo",
-            "description": "test desc for demo"
+            "description": "test desc for demo",
         },
         "shortcourse": {
             "url": "https://github.com/mrc-ide/wodin-shortcourse-2023",
             "ref": "main",
             "urlPath": "shortcourse",
-            "description": "test desc for shortcourse"
+            "description": "test desc for shortcourse",
         },
     }
     assert cfg.redis["name"] == "redis"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,7 +21,7 @@ def test_config_basic():
         },
     }
     assert cfg.redis["name"] == "redis"
-    assert str(cfg.redis["ref"]) == "library/redis:6"
+    assert str(cfg.redis["ref"]) == "library/redis:6.0"
     assert cfg.odin_api["name"] == "odin.api"
     assert str(cfg.odin_api["ref"]) == "test-repo/odin.api:main"
     assert cfg.wodin["name"] == "wodin"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,3 +30,38 @@ def test_config_basic():
     assert str(cfg.wodin_proxy["ref"]) == "test-repo/wodin-proxy:latest"
     assert cfg.wodin_proxy["port_http"] == 80
     assert cfg.wodin_proxy["port_https"] == 443
+    assert cfg.wodin_proxy["ssl_certificate"] == "test-cert"
+    assert cfg.wodin_proxy["ssl_key"] == "test-key"
+
+
+def test_config_basic_no_ssl():
+    cfg = WodinConfig("config/testNoSSL")
+    assert cfg.network == "test-network"
+    assert cfg.repo == "test-repo"
+    assert cfg.container_prefix == "test-prefix"
+    assert cfg.sites == {
+        "demo": {
+            "url": "https://github.com/mrc-ide/wodin-demo-config",
+            "ref": "main",
+            "urlPath": "demo",
+            "description": "test desc for demo",
+        },
+        "shortcourse": {
+            "url": "https://github.com/mrc-ide/wodin-shortcourse-2023",
+            "ref": "main",
+            "urlPath": "shortcourse",
+            "description": "test desc for shortcourse",
+        },
+    }
+    assert cfg.redis["name"] == "redis"
+    assert str(cfg.redis["ref"]) == "library/redis:6.0"
+    assert cfg.odin_api["name"] == "odin.api"
+    assert str(cfg.odin_api["ref"]) == "test-repo/odin.api:main"
+    assert cfg.wodin["name"] == "wodin"
+    assert str(cfg.wodin["ref"]) == "test-repo/wodin:main"
+    assert cfg.wodin_proxy["name"] == "wodin-proxy"
+    assert str(cfg.wodin_proxy["ref"]) == "test-repo/wodin-proxy:latest"
+    assert cfg.wodin_proxy["port_http"] == 80
+    assert cfg.wodin_proxy["port_https"] == 443
+    assert "ssl_certificate" not in cfg.wodin_proxy
+    assert "ssl_key" not in cfg.wodin_proxy

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,14 +20,25 @@ def test_config_basic():
             "description": "test desc for shortcourse",
         },
     }
-    assert cfg.redis["name"] == "redis"
+    assert cfg.redis["image_name"] == "redis"
     assert str(cfg.redis["ref"]) == "library/redis:6.0"
-    assert cfg.odin_api["name"] == "odin.api"
-    assert str(cfg.odin_api["ref"]) == "test-repo/odin.api:main"
-    assert cfg.wodin["name"] == "wodin"
+    assert cfg.redis["container_name"] == "redis"
+    assert cfg.redis["full_container_name"] == "test-prefix-redis"
+
+    assert cfg.odin_api["image_name"] == "odin-image"
+    assert str(cfg.odin_api["ref"]) == "test-repo/odin-image:main"
+    assert cfg.odin_api["container_name"] == "api"
+    assert cfg.odin_api["full_container_name"] == "test-prefix-api"
+
+    assert cfg.wodin["image_name"] == "wodin"
     assert str(cfg.wodin["ref"]) == "test-repo/wodin:main"
-    assert cfg.wodin_proxy["name"] == "wodin-proxy"
+    assert cfg.wodin["container_name"] == "wodin"
+    assert cfg.wodin["full_container_name"] == "test-prefix-wodin"
+
+    assert cfg.wodin_proxy["image_name"] == "wodin-proxy"
     assert str(cfg.wodin_proxy["ref"]) == "test-repo/wodin-proxy:main"
+    assert cfg.wodin_proxy["container_name"] == "wodin-proxy"
+    assert cfg.wodin_proxy["full_container_name"] == "test-prefix-wodin-proxy"
     assert cfg.wodin_proxy["port_http"] == 80
     assert cfg.wodin_proxy["port_https"] == 443
     assert cfg.wodin_proxy["ssl_certificate"] == "test-cert"
@@ -36,31 +47,6 @@ def test_config_basic():
 
 def test_config_basic_no_ssl():
     cfg = WodinConfig("config/testNoSSL")
-    assert cfg.network == "test-network"
-    assert cfg.repo == "test-repo"
-    assert cfg.container_prefix == "test-prefix"
-    assert cfg.sites == {
-        "demo": {
-            "url": "https://github.com/mrc-ide/wodin-demo-config",
-            "ref": "main",
-            "urlPath": "demo",
-            "description": "test desc for demo",
-        },
-        "shortcourse": {
-            "url": "https://github.com/mrc-ide/wodin-shortcourse-2023",
-            "ref": "main",
-            "urlPath": "shortcourse",
-            "description": "test desc for shortcourse",
-        },
-    }
-    assert cfg.redis["name"] == "redis"
-    assert str(cfg.redis["ref"]) == "library/redis:6.0"
-    assert cfg.odin_api["name"] == "odin.api"
-    assert str(cfg.odin_api["ref"]) == "test-repo/odin.api:main"
-    assert cfg.wodin["name"] == "wodin"
-    assert str(cfg.wodin["ref"]) == "test-repo/wodin:main"
-    assert cfg.wodin_proxy["name"] == "wodin-proxy"
-    assert str(cfg.wodin_proxy["ref"]) == "test-repo/wodin-proxy:main"
     assert cfg.wodin_proxy["port_http"] == 80
     assert cfg.wodin_proxy["port_https"] == 443
     assert "ssl_certificate" not in cfg.wodin_proxy

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,7 @@ def test_config_basic():
     assert cfg.wodin["name"] == "wodin"
     assert str(cfg.wodin["ref"]) == "test-repo/wodin:main"
     assert cfg.wodin_proxy["name"] == "wodin-proxy"
-    assert str(cfg.wodin_proxy["ref"]) == "test-repo/wodin-proxy:latest"
+    assert str(cfg.wodin_proxy["ref"]) == "test-repo/wodin-proxy:main"
     assert cfg.wodin_proxy["port_http"] == 80
     assert cfg.wodin_proxy["port_https"] == 443
     assert cfg.wodin_proxy["ssl_certificate"] == "test-cert"
@@ -60,7 +60,7 @@ def test_config_basic_no_ssl():
     assert cfg.wodin["name"] == "wodin"
     assert str(cfg.wodin["ref"]) == "test-repo/wodin:main"
     assert cfg.wodin_proxy["name"] == "wodin-proxy"
-    assert str(cfg.wodin_proxy["ref"]) == "test-repo/wodin-proxy:latest"
+    assert str(cfg.wodin_proxy["ref"]) == "test-repo/wodin-proxy:main"
     assert cfg.wodin_proxy["port_http"] == 80
     assert cfg.wodin_proxy["port_https"] == 443
     assert "ssl_certificate" not in cfg.wodin_proxy

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -15,6 +15,7 @@ def test_start_and_stop():
     obj.start()
 
     cl = docker.client.from_env()
+    cl.images.pull("library/redis:6")
 
     assert docker_util.network_exists(cfg.network)
     assert docker_util.volume_exists("redis-data")

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -12,6 +12,9 @@ def get_site_container_name(site, cfg):
 def test_start_and_stop():
     cl = docker.client.from_env()
     cl.images.pull("library/redis:6.0")
+    cl.images.pull("mrcide/odin.api:main")
+    cl.images.pull("mrcide/wodin-proxy:latest")
+    cl.images.pull("mrcide/wodin:main")
 
     cfg = WodinConfig("config/epimodels")
     obj = WodinConstellation(cfg)

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -2,11 +2,10 @@ import io
 from contextlib import redirect_stdout
 
 import docker
-import pytest
 from constellation import docker_util
 
 from wodin_deploy.config import WodinConfig
-from wodin_deploy.wodin_constellation import WodinConstellation, configure_wodin
+from wodin_deploy.wodin_constellation import WodinConstellation
 
 
 def get_site_container_name(site, cfg):
@@ -73,13 +72,3 @@ def test_obj_status():
     - wodin-infectiousdiseasemodels-2023 (epimodels-wodin-infectiousdiseasemodels-2023): missing
     - wodin-proxy (epimodels-wodin-proxy): missing\n"""
     )
-
-
-def test_wodin_throws_if_no_redis():
-    cfg = WodinConfig("config/epimodels")
-    cl = docker.client.from_env()
-    x = cl.containers.run("alpine:latest", name=f"{cfg.container_prefix}-{cfg.redis['name']}", detach=True)
-    with pytest.raises(Exception, match="Wodin could not connect to Redis"):
-        configure_wodin(None, cfg)
-    x.stop()
-    x.remove()

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -78,9 +78,7 @@ def test_obj_status():
 def test_wodin_throws_if_no_redis():
     cfg = WodinConfig("config/epimodels")
     cl = docker.client.from_env()
-    x = cl.containers.run("alpine:latest",
-                          name=f"{cfg.container_prefix}-{cfg.redis['name']}",
-                          detach=True)
+    x = cl.containers.run("alpine:latest", name=f"{cfg.container_prefix}-{cfg.redis['name']}", detach=True)
     with pytest.raises(Exception, match="Wodin could not connect to Redis"):
         configure_wodin(None, cfg)
     x.stop()

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -1,0 +1,31 @@
+from wodin_deploy.config import WodinConfig
+from wodin_deploy.wodin_constellation import WodinConstellation
+import docker
+from constellation import docker_util
+
+
+def get_site_container_name(site, cfg):
+    return f"{cfg.container_prefix}-{cfg.wodin['name']}-{site}"
+
+
+def test_start_and_stop():
+    cfg = WodinConfig("config/epimodels")
+    obj = WodinConstellation(cfg)
+    obj.start()
+
+    cl = docker.client.from_env()
+
+    assert docker_util.network_exists(cfg.network)
+    assert docker_util.volume_exists("redis-data")
+    assert docker_util.volume_exists("wodin-config")
+
+    assert docker_util.container_exists(f"{cfg.container_prefix}-api")
+    assert docker_util.container_exists(f"{cfg.container_prefix}-redis")
+    assert docker_util.container_exists(get_site_container_name("proxy", cfg))
+    for site in cfg.sites.keys():
+        assert docker_util.container_exists(get_site_container_name(site, cfg))
+
+    containers = cl.containers.list()
+    assert len(containers) == 3 + len(cfg.sites)
+
+    obj.stop(kill=True, remove_volumes=True)

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -10,7 +10,7 @@ from wodin_deploy.wodin_constellation import WodinConstellation
 
 
 def get_site_container_name(site, cfg):
-    return f"{cfg.container_prefix}-{cfg.wodin['name']}-{site}"
+    return f"{cfg.wodin['full_container_name']}-{site}"
 
 
 def pull_all_necessary_images(cl):

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -10,12 +10,12 @@ def get_site_container_name(site, cfg):
 
 
 def test_start_and_stop():
+    cl = docker.client.from_env()
+    cl.images.pull("library/redis:6.0")
+
     cfg = WodinConfig("config/epimodels")
     obj = WodinConstellation(cfg)
     obj.start()
-
-    cl = docker.client.from_env()
-    cl.images.pull("library/redis:6.0")
 
     assert docker_util.network_exists(cfg.network)
     assert docker_util.volume_exists("redis-data")

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -56,7 +56,7 @@ def test_obj_status():
         f.getvalue()
         == """Constellation wodin
   * Network:
-    - wodin-nw: created
+    - wodin-nw: missing
   * Volumes:
     - redis-data (redis-data): missing
     - wodin-config (wodin-config): missing

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -52,11 +52,11 @@ def test_obj_status():
     f = io.StringIO()
     with redirect_stdout(f):
         obj.status()
-    assert (
-        f.getvalue()
-        == """Constellation wodin
+
+    def status_string(network_status):
+        return f"""Constellation wodin
   * Network:
-    - wodin-nw: missing
+    - wodin-nw: {network_status}
   * Volumes:
     - redis-data (redis-data): missing
     - wodin-config (wodin-config): missing
@@ -71,4 +71,6 @@ def test_obj_status():
     - wodin-acomvec-2023 (epimodels-wodin-acomvec-2023): missing
     - wodin-infectiousdiseasemodels-2023 (epimodels-wodin-infectiousdiseasemodels-2023): missing
     - wodin-proxy (epimodels-wodin-proxy): missing\n"""
+    assert (
+        f.getvalue() == status_string("missing") or f.getvalue() == status_string("created")
     )

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -71,6 +71,5 @@ def test_obj_status():
     - wodin-acomvec-2023 (epimodels-wodin-acomvec-2023): missing
     - wodin-infectiousdiseasemodels-2023 (epimodels-wodin-infectiousdiseasemodels-2023): missing
     - wodin-proxy (epimodels-wodin-proxy): missing\n"""
-    assert (
-        f.getvalue() == status_string("missing") or f.getvalue() == status_string("created")
-    )
+
+    assert f.getvalue() == status_string("missing") or f.getvalue() == status_string("created")

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -52,7 +52,9 @@ def test_obj_status():
     f = io.StringIO()
     with redirect_stdout(f):
         obj.status()
-    assert f.getvalue() == """Constellation wodin
+    assert (
+        f.getvalue()
+        == """Constellation wodin
   * Network:
     - wodin-nw: created
   * Volumes:
@@ -69,3 +71,4 @@ def test_obj_status():
     - wodin-acomvec-2023 (epimodels-wodin-acomvec-2023): missing
     - wodin-infectiousdiseasemodels-2023 (epimodels-wodin-infectiousdiseasemodels-2023): missing
     - wodin-proxy (epimodels-wodin-proxy): missing\n"""
+    )

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -1,7 +1,8 @@
-from wodin_deploy.config import WodinConfig
-from wodin_deploy.wodin_constellation import WodinConstellation
 import docker
 from constellation import docker_util
+
+from wodin_deploy.config import WodinConfig
+from wodin_deploy.wodin_constellation import WodinConstellation
 
 
 def get_site_container_name(site, cfg):

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -2,10 +2,11 @@ import io
 from contextlib import redirect_stdout
 
 import docker
+import pytest
 from constellation import docker_util
 
 from wodin_deploy.config import WodinConfig
-from wodin_deploy.wodin_constellation import WodinConstellation
+from wodin_deploy.wodin_constellation import WodinConstellation, configure_wodin
 
 
 def get_site_container_name(site, cfg):
@@ -72,3 +73,15 @@ def test_obj_status():
     - wodin-infectiousdiseasemodels-2023 (epimodels-wodin-infectiousdiseasemodels-2023): missing
     - wodin-proxy (epimodels-wodin-proxy): missing\n"""
     )
+
+
+def test_wodin_throws_if_no_redis():
+    cfg = WodinConfig("config/epimodels")
+    cl = docker.client.from_env()
+    x = cl.containers.run("alpine:latest",
+                          name=f"{cfg.container_prefix}-{cfg.redis['name']}",
+                          detach=True)
+    with pytest.raises(Exception, match="Wodin could not connect to Redis"):
+        configure_wodin(None, cfg)
+    x.stop()
+    x.remove()

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -15,7 +15,7 @@ def test_start_and_stop():
     obj.start()
 
     cl = docker.client.from_env()
-    cl.images.pull("library/redis:6")
+    cl.images.pull("library/redis:6.0")
 
     assert docker_util.network_exists(cfg.network)
     assert docker_util.volume_exists("redis-data")

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -1,10 +1,12 @@
 import io
+from contextlib import redirect_stdout
+
 import docker
 from constellation import docker_util
-from contextlib import redirect_stdout
 
 from wodin_deploy.config import WodinConfig
 from wodin_deploy.wodin_constellation import WodinConstellation
+
 
 def get_site_container_name(site, cfg):
     return f"{cfg.container_prefix}-{cfg.wodin['name']}-{site}"

--- a/wodin_deploy/__about__.py
+++ b/wodin_deploy/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Rich FitzJohn <r.fitzjohn@imperial.ac.uk>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '0.0.1'
+__version__ = "0.0.1"

--- a/wodin_deploy/config.py
+++ b/wodin_deploy/config.py
@@ -33,7 +33,7 @@ class WodinConfig:
         self.wodin = self.get_base_config("wodin")
 
     def build_ref(self, section):
-        name = self.get_name(section)
+        name = self.get_image_name(section)
         if "repo" in self.dat[section]:
             repo = config.config_string(self.dat, [section, "repo"])
         else:
@@ -41,11 +41,23 @@ class WodinConfig:
         ref = config.config_string(self.dat, [section, "ref"])
         return constellation.ImageReference(repo, name, ref)
 
-    def get_name(self, section):
-        if "name" in self.dat[section]:
-            return config.config_string(self.dat, [section, "name"])
+    def get_image_name(self, section):
+        if "image_name" in self.dat[section]:
+            return config.config_string(self.dat, [section, "image_name"])
+        else:
+            return section
+
+    def get_container_name(self, section):
+        if "container_name" in self.dat[section]:
+            return config.config_string(self.dat, [section, "container_name"])
         else:
             return section
 
     def get_base_config(self, section):
-        return {"ref": self.build_ref(section), "name": self.get_name(section)}
+        container_name = self.get_container_name(section)
+        return {
+            "ref": self.build_ref(section),
+            "image_name": self.get_image_name(section),
+            "container_name": container_name,
+            "full_container_name": f"{self.container_prefix}-{container_name}",
+        }

--- a/wodin_deploy/config.py
+++ b/wodin_deploy/config.py
@@ -1,0 +1,60 @@
+import constellation
+from constellation import config
+
+
+class WodinConfig:
+    def __init__(self, path, extra=None, options=None):
+        dat = config.read_yaml(f"{path}.yml")
+        dat = config.config_build(path, dat, extra, options)
+        self.dat = dat
+        self.repo = config.config_string(dat, ["repo"])
+        self.path = path
+        self.vault = config.config_vault(dat, ["vault"])
+        self.network = config.config_string(dat, ["network"])
+        self.container_prefix = config.config_string(dat, ["container_prefix"])
+        self.sites = config.config_dict(dat, ["sites"])
+
+        # redis
+        self.redis = self.get_base_config("redis")
+
+        # odin.api
+        self.odin_api = self.get_base_config("odin.api")
+
+        # wodin-proxy
+        self.wodin_proxy = self.get_base_config("wodin-proxy")
+        self.wodin_proxy["port_http"] = config.config_integer(
+            dat, ["wodin-proxy", "port_http"])
+        self.wodin_proxy["port_https"] = config.config_integer(
+            dat, ["wodin-proxy", "port_https"])
+        self.proxy_ssl_self_signed = "ssl" not in dat["wodin-proxy"]
+        if not self.proxy_ssl_self_signed:
+            self.wodin_proxy["ssl_certificate"] = config.config_string(
+                dat, ["wodin-proxy", "ssl", "certificate"])
+            self.wodin_proxy["ssl_key"] = config.config_string(
+                dat, ["wodin-proxy", "ssl", "key"])
+
+        # wodin
+        self.wodin = self.get_base_config("wodin")
+
+        # self.vault = config.config_vault(dat, ["vault"])
+
+    def build_ref(self, section):
+        name = self.get_name(section)
+        if "repo" in self.dat[section]:
+            repo = config.config_string(self.dat, [section, "repo"])
+        else:
+            repo = self.repo
+        ref = config.config_string(self.dat, [section, "ref"])
+        return constellation.ImageReference(repo, name, ref)
+
+    def get_name(self, section):
+        if "name" in self.dat[section]:
+            return config.config_string(self.dat, [section, "name"])
+        else:
+            return section
+
+    def get_base_config(self, section):
+        return {
+            "ref": self.build_ref(section),
+            "name": self.get_name(section)
+        }

--- a/wodin_deploy/config.py
+++ b/wodin_deploy/config.py
@@ -22,16 +22,12 @@ class WodinConfig:
 
         # wodin-proxy
         self.wodin_proxy = self.get_base_config("wodin-proxy")
-        self.wodin_proxy["port_http"] = config.config_integer(
-            dat, ["wodin-proxy", "port_http"])
-        self.wodin_proxy["port_https"] = config.config_integer(
-            dat, ["wodin-proxy", "port_https"])
+        self.wodin_proxy["port_http"] = config.config_integer(dat, ["wodin-proxy", "port_http"])
+        self.wodin_proxy["port_https"] = config.config_integer(dat, ["wodin-proxy", "port_https"])
         self.proxy_ssl_self_signed = "ssl" not in dat["wodin-proxy"]
         if not self.proxy_ssl_self_signed:
-            self.wodin_proxy["ssl_certificate"] = config.config_string(
-                dat, ["wodin-proxy", "ssl", "certificate"])
-            self.wodin_proxy["ssl_key"] = config.config_string(
-                dat, ["wodin-proxy", "ssl", "key"])
+            self.wodin_proxy["ssl_certificate"] = config.config_string(dat, ["wodin-proxy", "ssl", "certificate"])
+            self.wodin_proxy["ssl_key"] = config.config_string(dat, ["wodin-proxy", "ssl", "key"])
 
         # wodin
         self.wodin = self.get_base_config("wodin")
@@ -54,7 +50,4 @@ class WodinConfig:
             return section
 
     def get_base_config(self, section):
-        return {
-            "ref": self.build_ref(section),
-            "name": self.get_name(section)
-        }
+        return {"ref": self.build_ref(section), "name": self.get_name(section)}

--- a/wodin_deploy/config.py
+++ b/wodin_deploy/config.py
@@ -32,8 +32,6 @@ class WodinConfig:
         # wodin
         self.wodin = self.get_base_config("wodin")
 
-        # self.vault = config.config_vault(dat, ["vault"])
-
     def build_ref(self, section):
         name = self.get_name(section)
         if "repo" in self.dat[section]:

--- a/wodin_deploy/wodin_constellation.py
+++ b/wodin_deploy/wodin_constellation.py
@@ -62,7 +62,8 @@ def configure_wodin(_, cfg):
         if "Ready to accept connections" in redis.logs().decode("utf-8"):
             return
         time.sleep(1)
-    raise Exception("Wodin could not connect to Redis")
+    msg = "Wodin could not connect to Redis"
+    raise Exception(msg)
 
 
 def get_wodin_container(cfg, site, path):

--- a/wodin_deploy/wodin_constellation.py
+++ b/wodin_deploy/wodin_constellation.py
@@ -60,8 +60,9 @@ def configure_wodin(_, cfg):
         cl = docker.client.from_env()
         redis = cl.containers.get(f"{cfg.container_prefix}-{cfg.redis['name']}")
         if "Ready to accept connections" in redis.logs().decode("utf-8"):
-            break
+            return
         time.sleep(1)
+    raise Exception("Wodin could not connect to Redis")
 
 
 def get_wodin_container(cfg, site, path):

--- a/wodin_deploy/wodin_constellation.py
+++ b/wodin_deploy/wodin_constellation.py
@@ -16,10 +16,7 @@ class WodinConstellation:
             cfg.container_prefix,
             containers,
             cfg.network,
-            {
-                "redis-data": "redis-data",
-                "wodin-config": "wodin-config"
-            },
+            {"redis-data": "redis-data", "wodin-config": "wodin-config"},
             data=cfg,
         )
 
@@ -56,14 +53,14 @@ def get_wodin_container(cfg, site, site_dict):
         network=cfg.network,
         entrypoint=[
             "/wodin/docker/pull-site-and-start.sh",
-            site_dict['ref'],
-            site_dict['url'],
+            site_dict["ref"],
+            site_dict["url"],
             f"/wodin/config/{site}",
             "--redis-url=redis://epimodels-redis:6379",
             "--odin-api=http://epimodels-api:8001",
             f"--base-url=http://localhost/{site_dict['urlPath']}",
-            f"/wodin/config/{site}"
-        ]
+            f"/wodin/config/{site}",
+        ],
     )
 
 
@@ -115,7 +112,5 @@ def wodin_proxy_container(cfg):
     args = ["localhost", *site_args]
     ports = [wodin_proxy["port_http"], wodin_proxy["port_https"]]
     return ConstellationContainer(
-        wodin_proxy["name"], wodin_proxy["ref"],
-        ports=ports, args=args,
-        configure=proxy_configure, network=cfg.network
+        wodin_proxy["name"], wodin_proxy["ref"], ports=ports, args=args, configure=proxy_configure, network=cfg.network
     )

--- a/wodin_deploy/wodin_constellation.py
+++ b/wodin_deploy/wodin_constellation.py
@@ -1,0 +1,137 @@
+import time
+from constellation import ConstellationMount, ConstellationContainer, Constellation, docker_util
+import subprocess
+
+
+class WodinConstellation:
+    def __init__(self, cfg):
+        self.cfg = cfg
+        redis = redis_container(cfg)
+        odin_api = odin_api_container(cfg)
+        sites = sites_containers(cfg)
+        proxy = wodin_proxy_container(cfg)
+
+        containers = [redis, odin_api] + sites + [proxy]
+
+        self.obj = Constellation(
+            "wodin", cfg.container_prefix,
+            containers, cfg.network,
+            {"redis-data": "redis-data", "wodin-config": "wodin-config"},
+            data=cfg
+        )
+
+    def start(self, **kwargs):
+        self.obj.start(**kwargs)
+
+    def stop(self, **kwargs):
+        self.obj.stop(**kwargs)
+
+    def status(self):
+        self.obj.status()
+
+
+def redis_container(cfg):
+    redis = cfg.redis
+    redis_mounts = [ConstellationMount("redis-data", "/data")]
+    return ConstellationContainer(redis["name"], redis["ref"], mounts=redis_mounts)
+
+
+def odin_api_container(cfg):
+    odin_api = cfg.odin_api
+    return ConstellationContainer("api", odin_api["ref"])
+
+
+def get_preconfigure(site, container_name, container_prefix):
+    return lambda x, data: subprocess.call([
+        "docker", "cp", "./siteConfigs/" + site,
+        container_prefix + "-" + container_name + ":/wodin/config/" + site
+    ])
+
+
+def configure_wodin(_, cfg):
+    for i in range(0, 10):
+        redis_log = subprocess.run([
+            "docker", "logs",
+            "{}-{}".format(cfg.container_prefix, cfg.redis["name"])
+        ], stdout=subprocess.PIPE)
+        if "Ready to accept connections" in redis_log.stdout.decode('utf-8'):
+            break
+        time.sleep(1)
+
+
+def get_wodin_container(cfg, site, path, sites):
+    wodin = cfg.wodin
+    container_prefix = cfg.container_prefix
+    wodin_mounts = [ConstellationMount("wodin-config", "/wodin/config")]
+    container_name = wodin["name"] + "-" + site
+    return ConstellationContainer(container_name, wodin["ref"], mounts=wodin_mounts,
+                                  args=[
+                                      "--redis-url=redis://epimodels-redis:6379",
+                                      "--odin-api=http://epimodels-api:8001",
+                                      "--base-url=http://localhost/" + path,
+                                      "/wodin/config/" + site
+                                  ],
+                                  configure=configure_wodin,
+                                  preconfigure=get_preconfigure(site, container_name, container_prefix))
+
+
+def sites_containers(cfg):
+    sites = cfg.sites
+    subprocess.call(["rm", "-rf", "./siteConfigs"])
+    subprocess.call(["mkdir", "./siteConfigs"])
+    wodin_containers = []
+    for site in sites.keys():
+        subprocess.call(["mkdir", "./siteConfigs/" + site])
+        site_dict = sites[site]
+        subprocess.call(["git", "clone", "--branch=" + site_dict["ref"], site_dict["url"], "./siteConfigs/" + site])
+        wodin_containers.append(get_wodin_container(cfg, site, site_dict["urlPath"], sites))
+    return wodin_containers
+
+
+def create_index_page(sites):
+    html_strings = [
+        "<html>\n<head>\n<title>Wodin</title>\n</head>\n<body>\n",
+        "<h1>Wodin</h1>\n",
+        "<p>There are {} deployed configurations:</p>\n".format(len(sites)),
+        "<ul>\n"
+    ]
+    for site in sites.keys():
+        site_obj = sites[site]
+        html_strings.append("<li><a href='/{}'><code>{}</code></a>: {}</li>\n"
+                            .format(site_obj["urlPath"], site, site_obj["description"]))
+    html_strings.append("</ul>\n</body>\n</html>")
+    return html_strings
+
+
+def proxy_configure(container, cfg):
+    docker_util.exec_safely(container, "mkdir /wodin/root")
+    subprocess.call(["mkdir", "-p", "./proxyIndexPage"])
+    sites = cfg.sites
+    html_strings = create_index_page(sites)
+    index_file = open("./proxyIndexPage/index.html", "w")
+    index_file.writelines(html_strings)
+    index_file.close()
+    subprocess.call(["docker", "cp", "./proxyIndexPage/index.html", "epimodels-wodin-proxy:/wodin/root"])
+
+
+def wodin_proxy_container(cfg):
+    wodin_proxy = cfg.wodin_proxy
+    sites = cfg.sites
+    container_prefix = cfg.container_prefix
+    wodin = cfg.wodin
+    site_args = []
+    for site in sites.keys():
+        site_args.append("--site")
+        url_path = sites[site]["urlPath"]
+        container_name = "{}-{}-{}".format(container_prefix, wodin["name"], site)
+        site_args.append("{}={}:3000".format(url_path, container_name))
+    args = ["localhost"] + site_args
+    ports = [wodin_proxy["port_http"], wodin_proxy["port_https"]]
+    return ConstellationContainer(
+        wodin_proxy["name"],
+        wodin_proxy["ref"],
+        ports=ports,
+        args=args,
+        configure=proxy_configure,
+        network=cfg.network
+    )

--- a/wodin_deploy/wodin_constellation.py
+++ b/wodin_deploy/wodin_constellation.py
@@ -93,7 +93,7 @@ def create_index_page(sites):
 
 
 def proxy_configure(container, cfg):
-    docker_util.exec_safely(container, "mkdir /wodin/root")
+    docker_util.exec_safely(container, "mkdir -p /wodin/root")
     html_string = create_index_page(cfg.sites)
     docker_util.string_into_container(html_string, container, "/wodin/root/index.html")
     docker_util.exec_safely(container, "chmod +r /wodin/root/index.html")

--- a/wodin_deploy/wodin_constellation.py
+++ b/wodin_deploy/wodin_constellation.py
@@ -43,6 +43,7 @@ def odin_api_container(cfg):
 
 def get_wodin_container(cfg, site, site_dict):
     wodin = cfg.wodin
+    prefix = cfg.container_prefix
     wodin_mounts = [ConstellationMount("wodin-config", "/wodin/config")]
     container_name = f"{wodin['name']}-{site}"
 
@@ -56,8 +57,8 @@ def get_wodin_container(cfg, site, site_dict):
             site_dict["ref"],
             site_dict["url"],
             f"/wodin/config/{site}",
-            "--redis-url=redis://epimodels-redis:6379",
-            "--odin-api=http://epimodels-api:8001",
+            f"--redis-url=redis://{prefix}-{cfg.redis['name']}:6379",
+            f"--odin-api=http://{prefix}-api:8001",
             f"--base-url=http://localhost/{site_dict['urlPath']}",
             f"/wodin/config/{site}",
         ],


### PR DESCRIPTION
This PR will add very basic functionality to the wodin deploy tool. I have included a couple of comments in the diff to explain the changes. This will add functionality to deploy on localhost with all the website configurations.

To test:
Add a breakpoint in the `test_constellation` file in the `test_start_and_stop` test before `obj.stop(...)`, run the test and when the python program pauses the website should be available on localhost.

Still to do:
* add functionality to deploy with SSL cert and key to epimodels.dide.ic.ac.uk (will involve also reading the vault config)
* CLI tool
* update sites functionality (way to update all the sites without tearing down all containers and restarting everything)

Note: I will be making tickets for the future PRs soon but they will follow the bullet points above!